### PR TITLE
Restart mathmlcloud api server unless explicitly stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,4 @@ services:
     links:
       - redis
       - mongo
+    restart: unless-stopped


### PR DESCRIPTION
The mathmlcloud api server had to be started manually frequently but
it's not clear why.  Add `restart: unless-stopped` to
`docker-compose.yml` to restart the api server automatically for now.